### PR TITLE
Add whistle's list of providers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.6
-MAINTAINER "Unif.io, Inc. <support@unif.io>"
+MAINTAINER "WhistleLabs, Inc. <devops@whistle.com>"
 
 # Loop through the list of providers that we want to include
 RUN apk add --no-cache --update ca-certificates gnupg openssl git mercurial wget unzip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add --no-cache --update ca-certificates gnupg openssl git mercurial wget
     aws:0.1.4 \
     consul:0.1.0 \
     datadog:0.1.1 \
+    github:0.1.1 \
     google:0.1.3 \
     heroku:0.1.0 \
     logentries:0.1.0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,15 @@ RUN apk add --no-cache --update ca-certificates gnupg openssl git mercurial wget
     gpg --keyserver keys.gnupg.net --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
     mkdir -p /usr/local/bin/terraform-providers && \
     for provider in \
-    aws:0.1.4; do \
+    aws:0.1.4 \
+    consul:0.1.0 \
+    datadog:0.1.1 \
+    google:0.1.3 \
+    heroku:0.1.0 \
+    logentries:0.1.0 \
+    newrelic:0.1.1 \
+    pagerduty:0.1.2 \
+    template:1.0.0; do \
         prov_name=`echo $provider | cut -d: -f1` && \
         prov_ver=`echo $provider | cut -d: -f2` && \
         echo "Installing provider ${prov_name} version ${prov_ver}" && \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Unif.io Terraform Provider Dockerfile
-[![Circle CI](https://circleci.com/gh/unifio/dockerfile-terraform-provider.svg?style=svg)](https://circleci.com/gh/unifio/dockerfile-terraform-provider)
+[![Circle CI](https://circleci.com/gh/WhistleLabs/dockerfile-terraform-provider.svg?style=svg)](https://circleci.com/gh/WhistleLabs/dockerfile-terraform-provider)
 
 ## What is terraform
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   environment:
-    DOCKER_IMAGE: 'unifio/terraform-providers'
+    DOCKER_IMAGE: 'whistle/terraform-providers'
     PROVIDER_VERSION: 0.0.1
   services:
     - docker


### PR DESCRIPTION
Created a new container that will contain the providers.  Whistle and Unif.io uses a different set of providers, so doesn't make sense to include in the terraform container.  The CI container will pull this in and copy providers into CI container path.